### PR TITLE
Add mailcatcher support

### DIFF
--- a/devbox/docker/images/php-5.6/Dockerfile
+++ b/devbox/docker/images/php-5.6/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 0xcbcb082a
 RUN add-apt-repository 'deb http://mirror.stshosting.co.uk/mariadb/repo/10.0/ubuntu trusty main'
 RUN apt-get -y update
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libcurl4-openssl-dev libcurl3 libyaml-dev php5 php5-mhash php5-mcrypt php5-curl php5-cli php5-mysql php5-gd php5-intl php-pear php5-dev php5-fpm php5-memcache mariadb-client-10.0
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y install libcurl4-openssl-dev libcurl3 libyaml-dev php5 php5-mhash php5-mcrypt php5-curl php5-cli php5-mysql php5-gd php5-intl php-pear php5-dev php5-fpm php5-memcache mariadb-client-10.0 ruby1.9.1-dev libsqlite3-dev
 
 RUN yes | pecl install yaml
 RUN echo "extension=yaml.so" >> /etc/php5/mods-available/yaml.ini
@@ -21,6 +21,10 @@ ADD www.conf /etc/php5/fpm/pool.d/www.conf
 RUN mkdir /etc/service/php-fpm
 ADD php-fpm.runit /etc/service/php-fpm/run
 ADD php-fpm-check.runit /etc/service/php-fpm/check
+
+RUN gem install mailcatcher --no-rdoc --no-ri &&\
+    sed -i -e "s/.*sendmail_path =.*/sendmail_path = \/usr\/bin\/env catchmail --smtp-ip mailcatcher -f address@example\.com/" /etc/php5/fpm/php.ini &&\
+    sed -i -e "s/.*sendmail_path =.*/sendmail_path = \/usr\/bin\/env catchmail --smtp-ip mailcatcher -f address@example\.com/" /etc/php5/cli/php.ini
 
 RUN curl -sS https://getcomposer.org/installer | php
 RUN mv composer.phar /usr/local/bin/composer

--- a/devbox/docker/run
+++ b/devbox/docker/run
@@ -35,8 +35,10 @@ echo "- MariaDB:"
 docker run -d --name devbox-mysql -v $MYSQLDIR:/var/lib/mysql -p 3306:3306 mixcom/devbox-mariadb-10.0
 echo "- Memcached:"
 docker run -d --name devbox-memcache memcached
+echo "- Mailcatcher:"
+docker run -d -p 1080:1080 --name devbox-mailcatcher alexisno/mailcatcher-dev
 echo "- PHP 5.6:"
-docker run -d --name devbox-php -v $ROOTDIR:/devbox -v $SITESDIR:/var/www/sites --link devbox-memcache:memcache --link devbox-mysql:mysql mixcom/devbox-php-5.6
+docker run -d --name devbox-php -v $ROOTDIR:/devbox -v $SITESDIR:/var/www/sites --link devbox-memcache:memcache --link devbox-mysql:mysql --link devbox-mailcatcher:mailcatcher mixcom/devbox-php-5.6
 docker exec devbox-php rsync -a /devbox/config/ssh-keys/ /root/.ssh
 echo "- Apache 2.4:"
 docker run -d --name devbox-apache -v $ROOTDIR:/var/www --link devbox-php:php -p 80:80 mixcom/devbox-apache-2.4


### PR DESCRIPTION
Mailcatcher is available on port 1080. Use ruby1.9.1-dev because mailcatcher needs it.
